### PR TITLE
Revert exclusion of `clang-compiler-activation-feedstock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 Note: version releases in the 0.x.y range may introduce breaking changes.
 
+## 0.1.7
+- Revert exclusion of `clang-compiler-activation-feedstock` from locally loaded feedstocks since it's actually active and needed.
+
 ## 0.1.6
 - Exclude `ctng-compiler-activation-feedstock`, `llvm-compilers-feedstock`, `clang-compilers-feedstock` and `clang-compiler-activation-feedstock` from locally loaded feedstocks because they are superseeded by other feedstocks.
 

--- a/percy/render/aggregate.py
+++ b/percy/render/aggregate.py
@@ -342,12 +342,6 @@ class Aggregate:
                     feedstock_name,
                 )
                 continue
-            if feedstock_name.startswith("clang-compiler-activation-"):
-                logging.warning(
-                    "Skipping feedstock %s now replaced by clangdev-feedstock",
-                    feedstock_name,
-                )
-                continue
             if "_cos6_" in feedstock_name or "_cos7_" in feedstock_name or "_amzn2_" in feedstock_name:
                 logging.warning("Skipping cdt %s", feedstock_name)
                 continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ namespaces = false
 
 [project]
 name = "percy"
-version = "0.1.6"
+version = "0.1.7"
 authors = [
   { name="Anaconda, Inc.", email="distribution_team@anaconda.com" },
 ]


### PR DESCRIPTION
It looks like I went a little bit too crazy on excluding stuff. `clang-compiler-activation-feedstock` is actually needed to get `clang_{target_platform}` and friends.