### PR TITLE
Add proper support for CDT packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 Note: version releases in the 0.x.y range may introduce breaking changes.
 
+## 0.1.8
+- Add proper support for CDT packages.
+
 ## 0.1.7
 - Revert exclusion of `clang-compiler-activation-feedstock` from locally loaded feedstocks since it's actually active and needed.
 

--- a/percy/render/_renderer.py
+++ b/percy/render/_renderer.py
@@ -196,6 +196,22 @@ def render(
             else:
                 return f"{compiler}_{selector_dict.get('target_platform', 'win-64')}"
 
+        # Based on https://github.com/conda/conda-build/blob/6d7805c97aa6de56346e62a9d1d3582cac00ddb8/conda_build/jinja_context.py#L559-L575
+        def expand_cdt(package_name: str) -> str:
+            arch = selector_dict["target_platform"].split("-", 1)[-1]
+
+            cdt_name = "cos6"
+            if arch == "ppc64le" or arch == "aarch64" or arch == "ppc64" or arch == "s390x":
+                cdt_name = "cos7"
+                cdt_arch = arch
+            else:
+                cdt_arch = "x86_64" if arch == "64" else "i686"
+
+            cdt_name = selector_dict.get("cdt_name", cdt_name)
+            cdt_arch = selector_dict.get("cdt_arch", cdt_arch)
+
+            return f"{package_name}-{cdt_name}-{cdt_arch}"
+
         jinja_vars: Final[dict[str, Any]] = {
             "unix": selector_dict.get("unix", False),
             "win": selector_dict.get("win", False),
@@ -224,7 +240,7 @@ def render(
             "compiler": expand_compiler,
             "pin_compatible": lambda x, max_pin=None, min_pin=None, lower_bound=None, upper_bound=None: f"{x} x",
             "pin_subpackage": lambda x, max_pin=None, min_pin=None, exact=False: f"{x} x",
-            "cdt": lambda x: f"{x}-cos6-x86_64",
+            "cdt": expand_cdt,
             "os.environ.get": lambda name, default="": "",
             "ccache": lambda name, method="": "ccache",
         }

--- a/percy/render/aggregate.py
+++ b/percy/render/aggregate.py
@@ -342,9 +342,6 @@ class Aggregate:
                     feedstock_name,
                 )
                 continue
-            if "_cos6_" in feedstock_name or "_cos7_" in feedstock_name or "_amzn2_" in feedstock_name:
-                logging.warning("Skipping cdt %s", feedstock_name)
-                continue
 
             # add to render list
             to_render.append((feedstock_repo, recipe_path, subdir, python, others, renderer))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ namespaces = false
 
 [project]
 name = "percy"
-version = "0.1.7"
+version = "0.1.8"
 authors = [
   { name="Anaconda, Inc.", email="distribution_team@anaconda.com" },
 ]


### PR DESCRIPTION
This PR adds proper support for CDT packages. The logic mostly follows what conda-build does. I say mostly because it's slightly simpler.