### PR TITLE
handle empty stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Note: version releases in the 0.x.y range may introduce breaking changes.
 ### Fixed
 ### Security
 
+## [0.2.6]
+### Added
+- fixed `stdlib('c')` substitution in `percy.render._renderer.render()`
+
 ## [0.2.5]
 ### Added
 - `stdlib('c')` substitution in `percy.render._renderer.render()`

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "percy" %}
-{% set version = "0.2.5" %}
+{% set version = "0.2.6" %}
 
 package:
   name: {{ name|lower }}

--- a/percy/render/_renderer.py
+++ b/percy/render/_renderer.py
@@ -192,7 +192,7 @@ def render(
         def expand_compiler(lang):
             compiler = selector_dict.get(f"{lang}_compiler", None)
             if compiler is None or not compiler:
-                return compiler
+                return f"compiler_{lang}"
             elif renderer_type == RendererType.RUAMEL:
                 return f"compiler_{lang}"
             return f"{compiler}_{selector_dict.get('target_platform', 'win-64')}"
@@ -200,7 +200,9 @@ def render(
         def expand_stdlib(lang):
             stdlib = selector_dict.get(f"{lang}_stdlib", None)
             if stdlib is None or not stdlib:
-                return stdlib
+                return f"stdlib_{lang}"
+            elif renderer_type == RendererType.RUAMEL:
+                return f"stdlib_{lang}"
             return f"{stdlib}_{selector_dict.get('target_platform', 'win-64')}"
 
         # Based on https://github.com/conda/conda-build/blob/6d7805c97aa6de56346e62a9d1d3582cac00ddb8/conda_build/jinja_context.py#L559-L575  # pylint: disable=line-too-long

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ namespaces = false
 
 [project]
 name = "percy"
-version = "0.2.5"
+version = "0.2.6"
 authors = [
   { name="Anaconda, Inc.", email="distribution_team@anaconda.com" },
 ]


### PR DESCRIPTION
handle empty stdlib - to not break the current linter (until next linter version is released).